### PR TITLE
Upgrade B2R2

### DIFF
--- a/src/PoE.Core/EvalTypes.fs
+++ b/src/PoE.Core/EvalTypes.fs
@@ -24,7 +24,7 @@
 
 namespace PoE
 
-open B2R2.FrontEnd.BinInterface
+open B2R2.FrontEnd
 
 type ConnectionInfo =
   | Network of ip: string * port: int

--- a/src/PoE.Core/PoE.Core.fsproj
+++ b/src/PoE.Core/PoE.Core.fsproj
@@ -43,8 +43,9 @@
   <ItemGroup>
     <PackageReference Include="FsLexYacc" Version="11.2.0" />
     <PackageReference Include="Microsoft.Z3" Version="4.12.2" />
-    <PackageReference Include="B2R2.FrontEnd.BinInterface" Version="0.6.1" />
-    <PackageReference Include="B2R2.Peripheral.Assembly.AsmInterface" Version="0.6.1" />
+    <PackageReference Include="B2R2.FrontEnd.API" Version="0.9.0" />
+    <PackageReference Include="B2R2.Peripheral.Assembly.API" Version="0.9.0" />
+    <PackageReference Include="B2R2.RearEnd.Utils" Version="0.9.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PoE.Core/StdBuf.fs
+++ b/src/PoE.Core/StdBuf.fs
@@ -37,12 +37,7 @@ module StdBuf =
     elif RuntimeInformation.IsOSPlatform OSPlatform.OSX then OS.MacOSX
     else raise UnknownOSException
 
-  let private getArch () =
-    match RuntimeInformation.OSArchitecture with
-    | Architecture.X86 -> Arch.IntelX86
-    | Architecture.X64 -> Arch.IntelX64
-    | Architecture.Arm64 -> Arch.AARCH64
-    | _ -> Arch.UnknownISA
+  let private getArch () = RuntimeInformation.OSArchitecture
 
   let private getPreloadKey = function
     | OS.Linux -> "LD_PRELOAD"
@@ -66,9 +61,9 @@ module StdBuf =
   let private getArchSuffix os arch =
     match arch with
     | _ when os = OS.MacOSX -> "macos-universal"
-    | Arch.IntelX86 -> "linux-x86"
-    | Arch.IntelX64 -> "linux-x64"
-    | Arch.AARCH64 -> "linux-aarch64"
+    | Architecture.X86 -> "linux-x86"
+    | Architecture.X64 -> "linux-x64"
+    | Architecture.Arm64 -> "linux-aarch64"
     | _ -> raise UnknownOSException
     
   let private setEnvironmentVariable key value sep (pInfo: ProcessStartInfo) =
@@ -82,8 +77,8 @@ module StdBuf =
     let arch = getArch ()
     match os, arch with
     | OS.Linux, _
-    | OS.MacOSX, Arch.IntelX64
-    | OS.MacOSX, Arch.AARCH64 ->
+    | OS.MacOSX, Architecture.X64
+    | OS.MacOSX, Architecture.Arm64 ->
       let suffix = getArchSuffix os arch
       let libDir = Path.GetFullPath AppDomain.CurrentDomain.BaseDirectory
       let libName = $"stdbuf-{suffix}"

--- a/src/PoE.Core/Stream.fs
+++ b/src/PoE.Core/Stream.fs
@@ -27,9 +27,7 @@ module PoE.Stream
 open System
 open System.IO
 open System.Threading.Tasks
-open B2R2
-
-let internal printer = ConsolePrinter ()
+open B2R2.RearEnd.Utils
 
 let [<Literal>] DefaultBufSize = 4096
 let [<Literal>] DefaultTimeout = 5000 (* 5 sec. *)
@@ -39,8 +37,8 @@ let [<Literal>] DefaultTimeout = 5000 (* 5 sec. *)
 let mutable debugStream = false
 
 let printColor (str: string) color =
-  printer.PrintLine [ (color, str.TrimEnd ()) ]
-  printer.Flush ()
+  Terminal.Out.PrintLine(ColoredString(color, str.TrimEnd()))
+  Terminal.Out.Flush ()
 
 let printDbg isOut bs =
   if debugStream then


### PR DESCRIPTION
Use latest B2R2, so that we don't rely on older .NET versions.