### PR TITLE
implement 'writeafter' built-in function

### DIFF
--- a/src/PoE.Core.Tests/PoE.Core.Tests.fsproj
+++ b/src/PoE.Core.Tests/PoE.Core.Tests.fsproj
@@ -11,6 +11,7 @@
     <Compile Include="TestHelper.fs" />
     <Compile Include="Executor\InlineAssemblyTests.fs" />
     <Compile Include="Executor\LoopTests.fs" />
+    <Compile Include="Executor\WriteAfterTests.fs" />
     <Compile Include="Tests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
This PR introduces the `writeafter` built-in function to the PoE interpreter. Inspired by **pwntools**' `sendafter`, it streamlines exploit scripts by combining read and write operations into a single call.

This makes the code more readable and concise.

## Features
The implementation is **polymorphic** and mimics the flexibility of the existing `read` function. It supports two modes for the first argument:

1.  **Delimiter Mode (String/BitVec):** Reads the stream until the specified delimiter is found (acts like `readuntil`).
2.  **Byte Count Mode (Int):** Reads a specific number of bytes (acts like `recvn`), useful if you need to read the output before writing

**Key behaviors:**
*   **Conditional Writing:** The payload (2nd argument) is sent only if the read operation succeeds (i.e., the delimiter is found or the byte count is satisfied).
*   **Return Value:** The function returns the data read from the stream (including the delimiter), allowing for easy data leakage extraction during the interaction.

## Usage Examples

### 1. Standard "sendafter" behavior
Waits for a specific prompt before sending the payload.

```python
# Reads until "Password: " is found, then sends "Admin\n"
writeafter("Password: ", "Admin\n")
```

### 2. Reading by byte count
Useful for skipping headers or reading fixed-size structures before sending data.

```python
# Reads 4 bytes, then sends "OK"
writeafter(4, "OK")
```

### 3. Capturing Leaks
Since `writeafter` returns the read buffer, it can be used to capture information immediately before a prompt.

```python
# 'leak' will contain everything read up to and including "Give me data:"
bv leak = writeafter("Give me data:", "Payload")
```

## Technical Details
*   Modified `src/PoE/Language/Builtins.fs`.
*   Added `WriteAfter` class inheriting from `BuiltInFunc`.
*   `ParamTypes` is set to `[TypeAny; TypeAny]` to support both `Int` and `BitVec` as the first argument, ensuring flexibility similar to the native `read` function.

## Checklist
- [x] Project compiles (`dotnet build`).
- [x] Tested locally against a target service (./msg binary from homework3).
- [x] Verified delimiter logic (String argument).
- [x] Verified byte-count logic (Int argument).
- [x] Verified return values (data leakage).